### PR TITLE
fix: Fix version lower bound of datadog provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.53.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 3.0.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 3.59 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.13 |
 
 ## Providers
@@ -17,7 +17,7 @@
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.53.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4 |
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | ~> 3.0.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | ~> 3.59 |
 | <a name="provider_time"></a> [time](#provider\_time) | >=0.13 |
 
 ## Modules

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 3.0.0"
+      version = "~> 3.59"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
**:bulb: Summary of the pull request**
The version constraint included a version that was not actually compatible with the used resources.
Updated to latest version as minimum to ensure that a version is selected with the correct feature set.
